### PR TITLE
Add build preparation and artifact upload to workflow

### DIFF
--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -35,3 +35,21 @@ jobs:
 
       - name: PHP-CS-Fixer ellenőrzés
         run: vendor/bin/php-cs-fixer fix --using-cache=no
+               - name: Build mappa előkészítése
+                 run: |
+                   mkdir build
+                   rsync -av --exclude=.git --exclude=build ./ ./build/
+
+      - name: Build kicsomagolása ZIP-be
+        run: |
+          cd build
+          zip -r ../build.zip .
+
+      - name: Artifact feltöltése
+        # noinspection UndefinedAction
+        uses: actions/upload-artifact@v4
+        with:
+          # noinspection UndefinedParamsPresent
+          name: php-build
+          # noinspection UndefinedParamsPresent
+          path: build.zip


### PR DESCRIPTION
This update introduces steps to prepare a build directory, package it into a ZIP file, and upload it as an artifact in the PHP lint workflow. These changes enhance the workflow by enabling artifacts to be preserved and accessed later.